### PR TITLE
Configuração do jest para o pacote de ui

### DIFF
--- a/packages/ui/jest.config.js
+++ b/packages/ui/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  roots: ['<rootDir>'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'json', 'jsx'],
+  testPathIgnorePatterns: ['<rootDir>[/\\\\](node_modules|.next)[/\\\\]'],
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(ts|tsx)$'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'babel-jest',
+  },
+  watchPlugins: [
+    'jest-watch-typeahead/filename',
+    'jest-watch-typeahead/testname',
+  ],
+  moduleNameMapper: {
+    '\\.(css|less|sass|scss)$': 'identity-obj-proxy',
+    '\\.(gif|ttf|eot|svg|png)$': '<rootDir>/test/__mocks__/fileMock.js',
+  },
+  moduleDirectories: ['<rootDir>/node_modules', 'node_modules'],
+  setupFilesAfterEnv: [
+    '@testing-library/jest-dom/extend-expect',
+    'jest-styled-components',
+    'jest-canvas-mock',
+  ],
+};

--- a/packages/ui/src/components/foundation/Text.test.tsx
+++ b/packages/ui/src/components/foundation/Text.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render, screen } from '../../infra/test/testUtils';
+
+import Text from './Text';
+
+describe('<Text />', () => {
+  it('should render text', () => {
+    render(<Text>custom text</Text>);
+
+    expect(screen.getByText(/custom text/)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/infra/_setup/__snapshots__/sample.test.tsx.snap
+++ b/packages/ui/src/infra/_setup/__snapshots__/sample.test.tsx.snap
@@ -1,9 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`sample snapshot 1`] = `
+.c0 {
+  background: #ff6a00;
+}
+
 <div>
   <div
-    class="sc-bdfBwQ iYkQxA"
+    class="c0"
   >
     Hi
   </div>


### PR DESCRIPTION
Propostas de mudanças:

- Adição do jest.config para o pacote de `ui`, seguindo os mesmos padrões de configurações já feitas no pacote `site`
- Como antes os testes em `ui` foram gerados sem as configurações do jest-styled-components, ele acabou gerando um snapshot com as classes do styled components (que mudam de teste para teste), por isso atualizei a versão do snapshot de exemplo.
- Adição de teste para o componente Text